### PR TITLE
feat: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @unitedwardrobe/bv-typescript @minitauros


### PR DESCRIPTION
It would be nice if we can auto-invite reviewers for the Dependabot PRs. Adding the CODEOWNERS file will allow me to configure the branch protection rules in such a way that they are auto-invited.