### PR TITLE
chore: Update dependabot settings to weekly + change owners to bv-go

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @unitedwardrobe/bv-typescript @minitauros
+* @unitedwardrobe/bv-go @minitauros

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
Because bv-go actually uses this. Change to weekly to prevent daily spam of relatively non-critical project.